### PR TITLE
Ajustes para deploy no ECS

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -40,5 +40,14 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           IMAGE_TAG: latest
         run: |
+          docker image rm $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG || true
           docker build --no-cache -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+
+      - name: Force new ECS deployment
+        run: |
+          aws ecs update-service \
+            --cluster microservices-cluster \
+            --service video-update-service \
+            --force-new-deployment \
+            --region us-east-1

--- a/src/adapter/driver/http/docs/swagger.json
+++ b/src/adapter/driver/http/docs/swagger.json
@@ -4,6 +4,9 @@
         "title": "Video API",
         "version": "1.0.0"
     },
+    "servers": [
+        { "url": "/video-upload-app" }
+    ],
     "security": [
         { "bearerAuth": [] }
     ],

--- a/src/adapter/driver/http/middlewares/validate-token.ts
+++ b/src/adapter/driver/http/middlewares/validate-token.ts
@@ -22,7 +22,7 @@ export default async function validateToken(
         const user = await container.validateTokenUseCase.execute({ authorization: authHeader })
 
         request.user = {
-            id: user.id,
+            id: String(user.id),
             email: user.email
         }
 

--- a/src/adapter/driver/http/server.ts
+++ b/src/adapter/driver/http/server.ts
@@ -11,10 +11,10 @@ export class HackaAPI {
         const app = express()
         
         app.use(express.json())
-        app.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerDocs))
+        app.use('/video-upload-app/docs', swaggerUi.serve, swaggerUi.setup(swaggerDocs))
 
         app.use(express.urlencoded({ extended: true }))
-        app.use('/video', videoRouter)
+        app.use('/video-upload-app/video', videoRouter)
         app.use('/health', (_req, res) => { res.status(200).json({ status: 'UP' }) })
         app.use(globalErrorHandler)
 


### PR DESCRIPTION
This pull request introduces updates to deployment workflows, API documentation, middleware, and server routing to enhance functionality and improve clarity. Key changes include forcing ECS deployments, adding a base path to the API, ensuring token validation robustness, and updating server routes.

### Deployment Workflow Enhancements:
* [`.github/workflows/deploy.yaml`](diffhunk://#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54R43-R53): Added a step to force ECS service deployment after pushing a new Docker image to ensure immediate updates in the `video-update-service`.

### API Documentation Updates:
* [`src/adapter/driver/http/docs/swagger.json`](diffhunk://#diff-016f147612338f9a2e34bbd2112d045790b190ad286f468fc4d5454dfa464346R7-R9): Added a `servers` section with the base path `/video-upload-app` to clarify API routing in Swagger documentation.

### Middleware Improvements:
* [`src/adapter/driver/http/middlewares/validate-token.ts`](diffhunk://#diff-3c5b2a7b0d1744986911abef45249df2b9d8754de27623a0e053df828edf3fadL25-R25): Updated the `validateToken` middleware to ensure the `user.id` is always stored as a string, improving consistency and reducing potential type-related errors.

### Server Routing Changes:
* [`src/adapter/driver/http/server.ts`](diffhunk://#diff-595a7ade6f859941b2144d3fa2c24a70cfd75594b2e0eaa6e335cf3c9e526cb9L14-R17): Updated server routes to include the `/video-upload-app` base path for API endpoints and Swagger documentation, aligning with the new API structure.