### PR TITLE
fix: deploy ECS via OIDC without relying on AWS Secrets

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,45 +1,45 @@
-name: Build and Push Docker Image to ECR
+name: Build and Push Docker Image to ECR and Redeploy ECS
 
 on:
   push:
+    branches: [ main ]
+  pull_request:
     branches:
       - main
+  workflow_dispatch:
 
-env:
-  ECR_REPOSITORY: hacka-app-video-upload
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
-  deploy-to-ecr:
+  build-and-deploy:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v2
         with:
-          # role-to-assume: arn:aws:iam::999999:role/gh-actions-hacka-app-video-upload-role
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
+          role-to-assume: arn:aws:iam::816069165502:role/gh-actions-video-upload-service-role
           aws-region: us-east-1
 
-      - name: Create ECR repository if it doesn't exist
-        run: |
-          aws ecr describe-repositories --repository-names $ECR_REPOSITORY || \
-          aws ecr create-repository --repository-name $ECR_REPOSITORY
-          
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@v1
 
-      - name: Build, tag, and push Docker image
+      - name: Build, tag, and push image to ECR (no cache)
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: hacka-app-video-upload
           IMAGE_TAG: latest
         run: |
+          echo "🔁 Forçando build sem cache..."
+          aws ecr describe-repositories --repository-names $ECR_REPOSITORY --region us-east-1 || \
+          aws ecr create-repository --repository-name $ECR_REPOSITORY --region us-east-1
+
           docker image rm $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG || true
           docker build --no-cache -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
@@ -48,6 +48,20 @@ jobs:
         run: |
           aws ecs update-service \
             --cluster microservices-cluster \
-            --service video-update-service \
+            --service video-upload-service \
             --force-new-deployment \
             --region us-east-1
+
+      - name: Get ALB DNS
+        id: get-alb-dns
+        run: |
+          ALB_DNS=$(aws elbv2 describe-load-balancers \
+            --names ms-shared-alb \
+            --region us-east-1 \
+            --query "LoadBalancers[0].DNSName" \
+            --output text)
+          echo "alb_dns=$ALB_DNS" >> $GITHUB_OUTPUT
+
+      - name: Print Swagger URL
+        run: |
+          echo "📄 Swagger disponível em: http://${{ steps.get-alb-dns.outputs.alb_dns }}/video-upload-app/docs"

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -1,3 +1,5 @@
+name: Sonarcloud
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
fix: deploy ECS via OIDC without relying on AWS Secrets

add grafana with allow